### PR TITLE
handle undefined response by rejecting promise instead of trying to a…

### DIFF
--- a/dark-sky-api.js
+++ b/dark-sky-api.js
@@ -67,7 +67,9 @@ class DarkSky {
                 json: true
             };
             req(options, (err, res, body) => {
-                if (res.statusCode !== 200 || err) {
+                if (typeof res == 'undefined') {
+                    reject('Unable to fetch forecast data.')
+                } else if (res.statusCode !== 200 || err) {
                     reject(`Script Error: ${err} \nAPI Response: ${res.statusCode} :: ${res.statusMessage}`)
                 }
                 resolve(body)


### PR DESCRIPTION
…ccess nonexistent property "statusCode"



We noticed when using this module on wxkb.io that sometimes the response is undefined and in those cases trying to access res.statusCode causes node to crash. This patch ensures the promise is rejected in those cases instead of trying to access nonexistent properties and crashing.