### PR TITLE
Do not read data if request returned an error

### DIFF
--- a/dark-sky-api.js
+++ b/dark-sky-api.js
@@ -58,7 +58,10 @@ class DarkSky {
             if(!this.lat || !this.long) reject("Request not sent. ERROR: Longitute or Latitude is missing.")
             this.generateReqUrl();
             req({ url: this.url, json: true }, (err, res, body) => {
-                err ? reject(`Forecast cannot be retrieved. ERROR: ${err}`) : null;
+                if (err) {
+                    reject(`Forecast cannot be retrieved. ERROR: ${err}`)
+                    return
+                }
                 res.statusCode !== 200 ? reject(`Forecast cannot be retrieved. Response: ${res.statusCode} ${res.statusMessage}`) : null;
                 resolve(body)
             })


### PR DESCRIPTION
It may be undefined in this case, throwing a TypeError while checking
status code on next line:

    /…/node_modules/dark-sky/dark-sky-api.js:62
                    res.statusCode !== 200 ? reject(`Forecast cannot be retrieved. Response: ${res.statusCode} ${res.statusMessage}`) : null;
                       ^
    
    TypeError: Cannot read property 'statusCode' of undefined
    at Request.req [as _callback] (/…/node_modules/dark-sky/dark-sky-api.js:62:20)
        at self.callback (/…/node_modules/request/request.js:186:22)
        at emitOne (events.js:96:13)
        at Request.emit (events.js:188:7)
        at Request.onRequestError (/…/node_modules/request/request.js:824:8)
        at emitOne (events.js:96:13)
        at ClientRequest.emit (events.js:188:7)
        at TLSSocket.socketErrorListener (_http_client.js:309:9)
        at emitOne (events.js:96:13)
        at TLSSocket.emit (events.js:188:7)
